### PR TITLE
PHP开启php-pecl-trace扩展会造成redis线程池创建后没有返回的问题。

### DIFF
--- a/zh-CN/quickstart/enviroment.md
+++ b/zh-CN/quickstart/enviroment.md
@@ -17,5 +17,6 @@
 - `xhprof`
 - `blackfire`
 - `zend`
+- `trace`
 
 


### PR DESCRIPTION
这个问题在经过测试，开启php-pecl-trace扩展会造成redis连接池的行为异常，但是并不会引起崩溃和报错，但是任何操作都没有返回数据。