### PR TITLE
fix: return $data in validator/customer-rules.md

### DIFF
--- a/zh-CN/validator/customer-rule.md
+++ b/zh-CN/validator/customer-rule.md
@@ -207,7 +207,7 @@ class AlphaDashRule implements RuleInterface
         }
         $rule = '/^[A-Za-z0-9\-\_]+$/';
         if (preg_match($rule, $data[$propertyName])) {
-            return [$data];
+            return $data;
         }
         $message = (empty($message)) ? sprintf('%s must be a email', $propertyName) : $message;
         throw new ValidatorException($message);


### PR DESCRIPTION
'return [$data]' causes the data passed to the next validator to deform